### PR TITLE
feat: deliver stargazer analysis pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
-# Provide a GitHub personal access token (PAT) with access to public data
-GITHUB_TOKEN=ghp_your_token_here
-
-# Optional rate-limit tuning
-RATE_LIMIT_QPS=1
-GRAPHQL_PAGE_SIZE=100
+GITHUB_TOKEN=your_personal_access_token
+# DATA_DIR=data
+# REPORTS_DIR=reports
+# DATABASE_PATH=data/openclaw_stargazers.db

--- a/README.md
+++ b/README.md
@@ -3,25 +3,99 @@
 Analysis toolkit to fetch and analyze stargazers of `openclaw/openclaw`, store results in SQLite, and generate a bot-likelihood report.
 
 ## Overview
-This repository contains scripts to:
-- Fetch stargazers via GitHub GraphQL (REST fallback) with pagination and rate-limit handling.
-- Store user and stargazer data in a normalized SQLite database.
-- Compute user metrics and a reproducible bot-likelihood score (0–100).
-- Generate aggregate statistics and figures (locations, account age, activity, companies, bot-score histograms, time series).
-- Produce a final report.
 
-## Status
-Initial scaffolding. Implementation will proceed in Issue #1 and a single PR per the workflow.
+The pipeline provides:
 
-## Quick Start (planned)
-1. Set `GITHUB_TOKEN` in your environment.
-2. Create a virtual environment and install dependencies from `requirements.txt`.
-3. Run fetch, metrics, analyze, and report scripts as documented in Issue #1.
+- Deterministic fetch of stargazers via GitHub GraphQL with retry/backoff and REST enrichment support.
+- Normalized SQLite persistence (repositories, users, stargazers, fetch runs, metrics).
+- Bot-heuristic metrics (score 0–100) and activity sampling.
+- Aggregated CSV outputs and rich figures for reporting.
+- Markdown report summarising findings with visuals.
+
+## Prerequisites
+
+- Python 3.12+
+- `pip` and basic build tooling (`libstdc++`, `zlib`).
+- A GitHub personal access token with `public_repo` scope. App/installation tokens require an accurate system clock.
+
+Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+If NumPy fails to load due to missing native libraries, ensure `libstdc++` and `zlib` development packages are installed (e.g., `apt install libstdc++6 zlib1g`).
+
+Copy `.env.example` to `.env` (or export the variables) and provide a valid `GITHUB_TOKEN`:
+
+```bash
+cp .env.example .env
+```
+
+## Usage
+
+All commands assume the virtual environment is active and the repository root is on `PYTHONPATH` (e.g., `export PYTHONPATH=$(pwd)`).
+
+1. **Fetch stargazers** (GraphQL primary, optional REST enrichment):
+   ```bash
+   python -m src.fetch --repo openclaw/openclaw --max-users 200 --rest-enrichment --events recent
+   ```
+   The fetch run is resumable via checkpoints stored in `fetch_runs`.
+
+2. **Compute bot metrics** (requires fetch data):
+   ```bash
+   python -m src.metrics --repo openclaw/openclaw --metrics-version bot-v1
+   ```
+
+3. **Generate aggregates and CSVs**:
+   ```bash
+   python -m src.analyze --repo openclaw/openclaw --metrics-version bot-v1 --out-dir reports/data
+   ```
+
+4. **Render figures and Markdown report**:
+   ```bash
+   python -m src.report --repo openclaw/openclaw --metrics-version bot-v1 \
+     --data-dir reports/data --fig-dir reports/figures --out-file reports/report.md
+   ```
+
+Outputs land in:
+
+- SQLite database: `data/openclaw_stargazers.db`
+- Analysis CSVs: `reports/data/*.csv`
+- Figures: `reports/figures/*.png`
+- Markdown report: `reports/report.md`
+
+## Offline Demo / Sample Data
+
+If GitHub access is unavailable, seed a deterministic demo dataset and run the downstream stages:
+
+```bash
+export GITHUB_TOKEN=offline
+export PYTHONPATH=$(pwd)
+python scripts/seed_sample_data.py
+python -m src.metrics --repo openclaw/openclaw --metrics-version bot-v1
+python -m src.analyze --repo openclaw/openclaw --metrics-version bot-v1 --out-dir reports/data
+python -m src.report --repo openclaw/openclaw --metrics-version bot-v1 \
+  --data-dir reports/data --fig-dir reports/figures --out-file reports/report.md
+```
+
+This generates a six-user dataset illustrating metric scoring, aggregate outputs, and the final report without calling the GitHub APIs.
+
+## Troubleshooting
+
+- **Invalid or expired token** – GitHub GraphQL returns `Timestamp outside allowed skew` when using installation tokens with a misconfigured clock. Use a PAT or fix clock skew.
+- **Rate limiting** – The clients automatically backoff; rerun the fetch after the reset window or reduce `--max-users`.
+- **Missing native libs** – Install `libstdc++`/`zlib` development packages if NumPy/Pandas cannot import.
 
 ## Ethics & Privacy
+
 - Uses only public GitHub APIs.
-- No raw emails are stored; only an `email_public` flag.
-- Heuristic bot classification; results are probabilistic.
+- No raw emails are stored; only a boolean `email_public` flag.
+- Bot heuristics are deterministic indicators, not definitive classifications.
 
 ## License
+
 MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-alembic
 matplotlib
 pandas
 python-dotenv
 pytest
 requests
-requests-cache
 seaborn
 sqlalchemy
-tabulate
-tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
-pandas
+alembic
 matplotlib
-seaborn
-requests
-gql
-sqlalchemy
+pandas
 python-dotenv
+pytest
+requests
+requests-cache
+seaborn
+sqlalchemy
+tabulate
+tenacity

--- a/scripts/seed_sample_data.py
+++ b/scripts/seed_sample_data.py
@@ -1,0 +1,248 @@
+"""Seed the SQLite database with deterministic sample data for demos."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import List
+
+from sqlalchemy import delete
+from sqlalchemy.orm import sessionmaker
+
+from src.config import load_config
+from src.db import FetchRun, Repository, Stargazer, User, UserMetric, init_db, session_scope
+from src.utils import utc_now
+
+
+def seed_sample_data(session_factory: sessionmaker) -> None:
+    now = utc_now()
+
+    with session_scope(session_factory) as session:
+        # Wipe existing data so repeated invocations remain deterministic.
+        session.execute(delete(UserMetric))
+        session.execute(delete(Stargazer))
+        session.execute(delete(FetchRun))
+        session.execute(delete(User))
+        session.execute(delete(Repository))
+
+        repo = Repository(full_name="openclaw/openclaw", github_repo_id=1103012935)
+        session.add(repo)
+        session.flush()
+
+        users: List[User] = []
+        users.append(
+            User(
+                github_id_int=1,
+                login="organic-captain",
+                type="User",
+                name="Organic Captain",
+                bio="Open source maintainer",
+                company="OpenClaw Labs",
+                location="San Francisco, CA",
+                created_at=now - timedelta(days=1800),
+                followers_count=320,
+                following_count=150,
+                public_repos_count=42,
+                public_gists_count=4,
+                hireable=True,
+                email_public=False,
+                verified_badge=True,
+                site="https://organic.example.com",
+            )
+        )
+        users.append(
+            User(
+                github_id_int=2,
+                login="automation-spark-bot",
+                type="Bot",
+                name=None,
+                bio=None,
+                company="Automation Squad",
+                location=None,
+                created_at=now - timedelta(days=12),
+                followers_count=0,
+                following_count=0,
+                public_repos_count=0,
+                public_gists_count=0,
+                hireable=False,
+                email_public=False,
+                verified_badge=False,
+                site=None,
+            )
+        )
+        users.append(
+            User(
+                github_id_int=3,
+                login="quiet-watcher",
+                type="User",
+                name="Quinn Watcher",
+                bio="Infrastructure at Scale",
+                company=None,
+                location="Berlin, Germany",
+                created_at=now - timedelta(days=4000),
+                followers_count=5,
+                following_count=45,
+                public_repos_count=12,
+                public_gists_count=1,
+                hireable=False,
+                email_public=False,
+                verified_badge=False,
+                site="https://quiet.example.net",
+            )
+        )
+        users.append(
+            User(
+                github_id_int=4,
+                login="ci-helper",
+                type="User",
+                name="CI Helper",
+                bio="CI automation account",
+                company="OpenClaw Automation",
+                location="Toronto, Canada",
+                created_at=now - timedelta(days=30),
+                followers_count=1,
+                following_count=1,
+                public_repos_count=1,
+                public_gists_count=0,
+                hireable=False,
+                email_public=False,
+                verified_badge=False,
+                site=None,
+            )
+        )
+        users.append(
+            User(
+                github_id_int=5,
+                login="research-ally",
+                type="User",
+                name="Research Ally",
+                bio="ML safety researcher",
+                company="Safety Initiative",
+                location="London, UK",
+                created_at=now - timedelta(days=2500),
+                followers_count=85,
+                following_count=62,
+                public_repos_count=18,
+                public_gists_count=3,
+                hireable=False,
+                email_public=True,
+                verified_badge=False,
+                site="https://ally.example.org",
+            )
+        )
+        users.append(
+            User(
+                github_id_int=6,
+                login="silent-fork",
+                type="User",
+                name=None,
+                bio=None,
+                company=None,
+                location=None,
+                created_at=now - timedelta(days=5),
+                followers_count=0,
+                following_count=0,
+                public_repos_count=0,
+                public_gists_count=0,
+                hireable=False,
+                email_public=False,
+                verified_badge=False,
+                site=None,
+            )
+        )
+
+        session.add_all(users)
+        session.flush()
+
+        stargazers = []
+        for idx, user in enumerate(users, start=1):
+            starred_at = now - timedelta(days=idx * 7)
+            stargazers.append(
+                Stargazer(
+                    repository_id=repo.id,
+                    user_id=user.id,
+                    starred_at=starred_at,
+                    first_seen_at=starred_at,
+                    last_seen_at=starred_at,
+                    source="seed",
+                )
+            )
+        session.add_all(stargazers)
+
+        fetch_run = FetchRun(
+            started_at=now - timedelta(minutes=10),
+            ended_at=now - timedelta(minutes=5),
+            repo_full_name=repo.full_name,
+            api="seed",
+            page_size=100,
+            page_checkpoint=len(stargazers),
+            last_starred_at_seen=stargazers[0].starred_at,
+            success=True,
+            notes="Seeded demo dataset",
+        )
+        session.add(fetch_run)
+        session.flush()
+
+        metrics_seed = [
+            UserMetric(
+                user_id=users[0].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=now - timedelta(days=10),
+                recent_event_count_90d=42,
+                source_run_id=fetch_run.id,
+            ),
+            UserMetric(
+                user_id=users[1].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=now - timedelta(days=120),
+                recent_event_count_90d=0,
+                source_run_id=fetch_run.id,
+            ),
+            UserMetric(
+                user_id=users[2].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=now - timedelta(days=45),
+                recent_event_count_90d=3,
+                source_run_id=fetch_run.id,
+            ),
+            UserMetric(
+                user_id=users[3].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=now - timedelta(days=2),
+                recent_event_count_90d=18,
+                source_run_id=fetch_run.id,
+            ),
+            UserMetric(
+                user_id=users[4].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=now - timedelta(days=60),
+                recent_event_count_90d=5,
+                source_run_id=fetch_run.id,
+            ),
+            UserMetric(
+                user_id=users[5].id,
+                metrics_version="events-sampled",
+                updated_at=now,
+                last_public_activity_date=None,
+                recent_event_count_90d=0,
+                source_run_id=fetch_run.id,
+            ),
+        ]
+        session.add_all(metrics_seed)
+
+
+def main() -> None:
+    config = load_config()
+    engine = init_db(config.database_url)
+    session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+    seed_sample_data(session_factory)
+    print("Seeded sample data set with 6 stargazers.")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/src/analyze.py
+++ b/src/analyze.py
@@ -1,0 +1,231 @@
+"""Generate aggregate analytics from computed bot metrics."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from sqlalchemy import and_, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from .config import AppConfig, load_config
+from .db import Repository, Stargazer, User, UserMetric, init_db, session_scope
+from .utils import setup_logging, utc_now
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AnalyzerArgs:
+    repo: str
+    metrics_version: str
+    out_dir: Path
+
+
+def load_analysis_dataframe(session: Session, repo: str, metrics_version: str) -> pd.DataFrame:
+    """Load a DataFrame of users, metrics, and stargazer metadata for a repo."""
+
+    stmt = (
+        select(
+            User.id.label("user_id"),
+            User.login.label("login"),
+            User.type.label("account_type"),
+            User.site_admin.label("site_admin"),
+            User.company.label("company"),
+            User.location.label("location"),
+            User.created_at.label("created_at"),
+            User.followers_count.label("followers_count"),
+            User.following_count.label("following_count"),
+            User.public_repos_count.label("public_repos_count"),
+            User.public_gists_count.label("public_gists_count"),
+            User.hireable.label("hireable"),
+            User.verified_badge.label("verified_badge"),
+            UserMetric.bot_score.label("bot_score"),
+            UserMetric.bot_label.label("bot_label"),
+            UserMetric.last_public_activity_date.label("last_public_activity_date"),
+            UserMetric.recent_event_count_90d.label("recent_event_count_90d"),
+            UserMetric.follower_following_ratio.label("follower_following_ratio"),
+            Stargazer.starred_at.label("starred_at"),
+        )
+        .select_from(User)
+        .join(Stargazer, Stargazer.user_id == User.id)
+        .join(Repository, Repository.id == Stargazer.repository_id)
+        .join(
+            UserMetric,
+            and_(
+                UserMetric.user_id == User.id,
+                UserMetric.metrics_version == metrics_version,
+            ),
+            isouter=True,
+        )
+        .where(Repository.full_name == repo)
+    )
+
+    rows = session.execute(stmt).all()
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows, columns=[col.key for col in stmt.exported_columns])
+    df["starred_at"] = pd.to_datetime(df["starred_at"], utc=True)
+    if "created_at" in df.columns:
+        df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
+    if "last_public_activity_date" in df.columns:
+        df["last_public_activity_date"] = pd.to_datetime(df["last_public_activity_date"], utc=True)
+
+    now = utc_now()
+    df["account_age_days"] = df["created_at"].apply(lambda ts: (now - ts).days if pd.notnull(ts) else None)
+    return df
+
+
+class Analyzer:
+    """Creates CSV aggregates for downstream reporting."""
+
+    def __init__(self, config: AppConfig, args: argparse.Namespace):
+        self.config = config
+        self.args = AnalyzerArgs(
+            repo=args.repo,
+            metrics_version=args.metrics_version,
+            out_dir=Path(args.out_dir),
+        )
+        engine = init_db(config.database_url)
+        self.session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    def run(self) -> None:
+        self.args.out_dir.mkdir(parents=True, exist_ok=True)
+
+        with session_scope(self.session_factory) as session:
+            df = load_analysis_dataframe(session, self.args.repo, self.args.metrics_version)
+
+        if df.empty:
+            logger.warning("No metrics available. Run fetch and metrics before analyze.")
+            return
+
+        timestamp = utc_now().isoformat()
+        raw_path = self.args.out_dir / "stargazers_raw.csv"
+        df.to_csv(raw_path, index=False)
+        logger.info("Wrote raw dataset to %s", raw_path)
+
+        self._write_bot_distribution(df)
+        self._write_locations(df)
+        self._write_account_age(df)
+        self._write_activity(df)
+        self._write_companies(df)
+        self._write_bot_score_histogram(df)
+        self._write_stars_time_series(df)
+
+        summary_path = self.args.out_dir / "analysis_metadata.txt"
+        summary_path.write_text(f"generated_at={timestamp}\nrows={len(df)}\n")
+
+    def _write_bot_distribution(self, df: pd.DataFrame) -> None:
+        if "bot_label" not in df.columns:
+            return
+        distribution = df["bot_label"].dropna().value_counts().rename_axis("bot_label").reset_index(name="count")
+        path = self.args.out_dir / "bot_label_distribution.csv"
+        distribution.to_csv(path, index=False)
+
+    def _write_locations(self, df: pd.DataFrame) -> None:
+        locations = (
+            df["location"]
+            .dropna()
+            .astype(str)
+            .str.strip()
+            .replace({"": None})
+            .dropna()
+            .str.title()
+            .value_counts()
+            .head(10)
+            .rename_axis("location")
+            .reset_index(name="count")
+        )
+        path = self.args.out_dir / "top_locations.csv"
+        locations.to_csv(path, index=False)
+
+    def _write_account_age(self, df: pd.DataFrame) -> None:
+        ages = df["account_age_days"].dropna()
+        if ages.empty:
+            return
+        bins = [0, 7, 30, 90, 365, 730, 1825, float("inf")]
+        labels = ["<1w", "<1m", "<3m", "<1y", "<2y", "<5y", ">=5y"]
+        categorized = pd.cut(ages, bins=bins, labels=labels, right=False)
+        result = categorized.value_counts(sort=False).rename_axis("account_age").reset_index(name="count")
+        path = self.args.out_dir / "account_age_distribution.csv"
+        result.to_csv(path, index=False)
+
+    def _write_activity(self, df: pd.DataFrame) -> None:
+        activity = df[["recent_event_count_90d", "last_public_activity_date"]].copy()
+        activity["recent_event_count_90d"] = activity["recent_event_count_90d"].fillna(0)
+        now = utc_now()
+        activity["days_since_last_activity"] = activity["last_public_activity_date"].apply(
+            lambda ts: (now - ts).days if pd.notnull(ts) else None
+        )
+        summary = {
+            "mean_recent_events": activity["recent_event_count_90d"].mean(),
+            "median_recent_events": activity["recent_event_count_90d"].median(),
+            "inactive_over_180d": activity["days_since_last_activity"].apply(lambda d: d is not None and d > 180).sum(),
+        }
+        path = self.args.out_dir / "activity_summary.csv"
+        pd.Series(summary).to_csv(path)
+
+    def _write_companies(self, df: pd.DataFrame) -> None:
+        companies = (
+            df["company"]
+            .dropna()
+            .astype(str)
+            .str.strip()
+            .replace({"": None})
+            .dropna()
+            .value_counts()
+            .head(10)
+            .rename_axis("company")
+            .reset_index(name="count")
+        )
+        path = self.args.out_dir / "top_companies.csv"
+        companies.to_csv(path, index=False)
+
+    def _write_bot_score_histogram(self, df: pd.DataFrame) -> None:
+        scores = df["bot_score"].dropna()
+        if scores.empty:
+            return
+        bins = list(range(0, 101, 10))
+        categorized = pd.cut(scores, bins=bins, right=False, include_lowest=True)
+        histogram = categorized.value_counts(sort=False).rename_axis("score_bin").reset_index(name="count")
+        path = self.args.out_dir / "bot_score_histogram.csv"
+        histogram.to_csv(path, index=False)
+
+    def _write_stars_time_series(self, df: pd.DataFrame) -> None:
+        stars = df[["starred_at"]].dropna().copy()
+        if stars.empty:
+            return
+        starred_series = stars["starred_at"]
+        if starred_series.dt.tz is not None:
+            starred_series = starred_series.dt.tz_localize(None)
+        stars["month"] = starred_series.dt.to_period("M").dt.to_timestamp()
+        timeline = stars.groupby("month").size().reset_index(name="stars")
+        path = self.args.out_dir / "stars_time_series.csv"
+        timeline.to_csv(path, index=False)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze stargazer bot metrics")
+    parser.add_argument("--repo", default="openclaw/openclaw", help="Repository in owner/name format")
+    parser.add_argument("--metrics-version", default="bot-v1", help="Metrics version to analyze")
+    parser.add_argument("--out-dir", default="reports/data", help="Directory for CSV outputs")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    setup_logging(verbose=args.verbose)
+    config = load_config()
+    analyzer = Analyzer(config, args)
+    analyzer.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,94 @@
+"""Application configuration loading utilities.
+
+This module is boundary-layer code responsible for reading environment
+variables, validating configuration, and preparing directories used by the
+pipeline. Internal modules consume the resulting ``AppConfig`` dataclass and
+may assume that all invariants expressed here hold true.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_DATA_DIR = BASE_DIR / "data"
+DEFAULT_REPORTS_DIR = BASE_DIR / "reports"
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    """Runtime configuration for the stargazer analysis pipeline."""
+
+    github_token: str
+    database_url: str
+    data_dir: Path
+    reports_dir: Path
+    request_timeout: int = 20
+    max_retries: int = 5
+    backoff_min_seconds: float = 1.0
+    backoff_max_seconds: float = 30.0
+    default_page_size: int = 100
+
+
+def _resolve_database_url(raw_url: Optional[str], raw_path: Optional[str]) -> str:
+    """Resolve the configured database URL, validating SQLite paths."""
+
+    if raw_url:
+        return raw_url
+
+    path = Path(raw_path) if raw_path else DEFAULT_DATA_DIR / "openclaw_stargazers.db"
+    if not path.is_absolute():
+        path = BASE_DIR / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite:///{path}"
+
+
+def load_config(env_file: Optional[Path] = None) -> AppConfig:
+    """Load configuration from environment variables and optional ``.env`` file."""
+
+    candidate_env = env_file if env_file is not None else BASE_DIR / ".env"
+    if candidate_env.exists():
+        load_dotenv(dotenv_path=candidate_env)
+    else:
+        load_dotenv()
+
+    github_token = os.getenv("GITHUB_TOKEN")
+    if not github_token:
+        raise ValueError("GITHUB_TOKEN must be set in the environment before running the pipeline.")
+
+    data_dir = Path(os.getenv("DATA_DIR", DEFAULT_DATA_DIR))
+    if not data_dir.is_absolute():
+        data_dir = BASE_DIR / data_dir
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    reports_dir = Path(os.getenv("REPORTS_DIR", DEFAULT_REPORTS_DIR))
+    if not reports_dir.is_absolute():
+        reports_dir = BASE_DIR / reports_dir
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    database_url = _resolve_database_url(os.getenv("DATABASE_URL"), os.getenv("DATABASE_PATH"))
+
+    request_timeout = int(os.getenv("GITHUB_REQUEST_TIMEOUT", "20"))
+    max_retries = int(os.getenv("GITHUB_MAX_RETRIES", "5"))
+    backoff_min_seconds = float(os.getenv("GITHUB_BACKOFF_MIN", "1.0"))
+    backoff_max_seconds = float(os.getenv("GITHUB_BACKOFF_MAX", "30.0"))
+    default_page_size = int(os.getenv("GITHUB_PAGE_SIZE", "100"))
+
+    return AppConfig(
+        github_token=github_token,
+        database_url=database_url,
+        data_dir=data_dir,
+        reports_dir=reports_dir,
+        request_timeout=request_timeout,
+        max_retries=max_retries,
+        backoff_min_seconds=backoff_min_seconds,
+        backoff_max_seconds=backoff_max_seconds,
+        default_page_size=default_page_size,
+    )
+

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,184 @@
+"""Database models and helpers for stargazer persistence."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Iterator, Optional
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    event,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, relationship, sessionmaker
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for ORM models."""
+
+
+class Repository(Base):
+    """Tracked GitHub repository."""
+
+    __tablename__ = "repositories"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    full_name: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    github_repo_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    stargazers: Mapped[list["Stargazer"]] = relationship("Stargazer", back_populates="repository")
+
+
+class User(Base):
+    """GitHub account that starred the repository."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    github_id_int: Mapped[int] = mapped_column(Integer, unique=True, nullable=False)
+    login: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    type: Mapped[str] = mapped_column(String(32), nullable=False)
+    site_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    name: Mapped[Optional[str]] = mapped_column(String(200))
+    bio: Mapped[Optional[str]] = mapped_column(Text())
+    company: Mapped[Optional[str]] = mapped_column(String(200))
+    location: Mapped[Optional[str]] = mapped_column(String(200))
+    created_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    followers_count: Mapped[Optional[int]] = mapped_column(Integer)
+    following_count: Mapped[Optional[int]] = mapped_column(Integer)
+    public_repos_count: Mapped[Optional[int]] = mapped_column(Integer)
+    public_gists_count: Mapped[Optional[int]] = mapped_column(Integer)
+    hireable: Mapped[Optional[bool]] = mapped_column(Boolean)
+    email_public: Mapped[Optional[bool]] = mapped_column(Boolean)
+    verified_badge: Mapped[Optional[bool]] = mapped_column(Boolean)
+    site: Mapped[Optional[str]] = mapped_column(String(300))
+
+    stargazer_entries: Mapped[list["Stargazer"]] = relationship("Stargazer", back_populates="user")
+    metrics: Mapped[list["UserMetric"]] = relationship("UserMetric", back_populates="user")
+
+
+class Stargazer(Base):
+    """Association table linking repositories and users with star metadata."""
+
+    __tablename__ = "stargazers"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    repository_id: Mapped[int] = mapped_column(ForeignKey("repositories.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    starred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    first_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    source: Mapped[str] = mapped_column(String(32), nullable=False, default="graphql")
+
+    repository: Mapped["Repository"] = relationship("Repository", back_populates="stargazers")
+    user: Mapped["User"] = relationship("User", back_populates="stargazer_entries")
+
+    __table_args__ = (UniqueConstraint("repository_id", "user_id", name="uq_stargazers_repo_user"),)
+
+
+class FetchRun(Base):
+    """Records the lifecycle of a single fetch execution."""
+
+    __tablename__ = "fetch_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    repo_full_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    api: Mapped[str] = mapped_column(String(32), nullable=False)
+    page_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    cursor_checkpoint: Mapped[Optional[str]] = mapped_column(String(256))
+    page_checkpoint: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_starred_at_seen: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    rate_limit_limit: Mapped[Optional[int]] = mapped_column(Integer)
+    rate_limit_remaining: Mapped[Optional[int]] = mapped_column(Integer)
+    rate_limit_reset_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    rate_limit_used: Mapped[Optional[int]] = mapped_column(Integer)
+    success: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    error_message: Mapped[Optional[str]] = mapped_column(Text())
+    notes: Mapped[Optional[str]] = mapped_column(Text())
+
+    metrics: Mapped[list["UserMetric"]] = relationship("UserMetric", back_populates="source_run")
+
+
+class UserMetric(Base):
+    """Computed metrics and bot score for a user."""
+
+    __tablename__ = "user_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    last_public_activity_date: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    recent_event_count_90d: Mapped[Optional[int]] = mapped_column(Integer)
+    follower_following_ratio: Mapped[Optional[float]] = mapped_column(Float)
+    bot_score: Mapped[Optional[int]] = mapped_column(Integer)
+    bot_label: Mapped[Optional[str]] = mapped_column(String(32))
+    metrics_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    source_run_id: Mapped[Optional[int]] = mapped_column(ForeignKey("fetch_runs.id"))
+
+    user: Mapped["User"] = relationship("User", back_populates="metrics")
+    source_run: Mapped[Optional["FetchRun"]] = relationship("FetchRun", back_populates="metrics")
+
+    __table_args__ = (UniqueConstraint("user_id", "metrics_version", name="uq_user_metrics_version"),)
+
+
+def _ensure_sqlite_foreign_keys(engine: Engine) -> None:
+    """Enable foreign key enforcement for SQLite connections."""
+
+    if not engine.url.drivername.startswith("sqlite"):
+        return
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, connection_record):  # type: ignore[unused-ignore]
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+def create_db_engine(database_url: str) -> Engine:
+    """Create a SQLAlchemy engine with sensible defaults."""
+
+    engine = create_engine(database_url, echo=False, future=True)
+    _ensure_sqlite_foreign_keys(engine)
+    return engine
+
+
+def create_session_factory(database_url: str) -> sessionmaker[Session]:
+    """Create a configured session factory for the database URL."""
+
+    engine = create_db_engine(database_url)
+    return sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+
+def init_db(database_url: str) -> Engine:
+    """Initialise the database by creating all known tables."""
+
+    engine = create_db_engine(database_url)
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@contextmanager
+def session_scope(session_factory: sessionmaker[Session]) -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -1,0 +1,326 @@
+"""CLI entry point for fetching stargazers into SQLite."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from .config import AppConfig, load_config
+from .db import FetchRun, Repository, Stargazer, User, UserMetric, init_db, session_scope
+from .github_graphql import GithubGraphQLClient, StargazerEdge
+from .github_rest import GithubRestClient
+from .utils import setup_logging, utc_now
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UserSnapshot:
+    github_id: int
+    login: str
+    account_type: str
+    site_admin: Optional[bool]
+    name: Optional[str]
+    bio: Optional[str]
+    company: Optional[str]
+    location: Optional[str]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+    followers: Optional[int]
+    following: Optional[int]
+    public_repos: Optional[int]
+    public_gists: Optional[int]
+    hireable: Optional[bool]
+    email_public: Optional[bool]
+    verified: Optional[bool]
+    site: Optional[str]
+
+
+class FetchRunner:
+    """Handles the stargazer fetching workflow."""
+
+    def __init__(self, config: AppConfig, args: argparse.Namespace):
+        self.config = config
+        self.args = args
+        self.graphql = GithubGraphQLClient(config)
+        self.rest = GithubRestClient(config) if self._needs_rest_client else None
+        engine = init_db(config.database_url)
+        self.session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    @property
+    def _needs_rest_client(self) -> bool:
+        return self.args.rest_enrichment or self.args.events != "none"
+
+    def run(self) -> None:
+        with session_scope(self.session_factory) as session:
+            repository = self._get_or_create_repository(session, self.args.repo)
+            resume_cursor, resume_page = self._load_resume_state(session)
+            fetch_run = self._start_fetch_run(session, resume_cursor, resume_page)
+            session.flush()
+
+            total_processed = 0
+            page_number = resume_page
+            try:
+                for page in self.graphql.iter_stargazers(
+                    repo_full_name=self.args.repo,
+                    page_size=self.args.page_size or self.config.default_page_size,
+                    start_cursor=resume_cursor,
+                    max_users=self.args.max_users,
+                ):
+                    page_number += 1
+                    processed = self._process_page(session, repository, fetch_run, page.edges)
+                    total_processed += processed
+
+                    if processed:
+                        fetch_run.cursor_checkpoint = page.end_cursor
+                        fetch_run.page_checkpoint = page_number
+                        fetch_run.last_starred_at_seen = page.edges[-1].starred_at
+                    fetch_run.rate_limit_limit = page.rate_limit.limit
+                    fetch_run.rate_limit_remaining = page.rate_limit.remaining
+                    fetch_run.rate_limit_reset_at = page.rate_limit.reset_at
+                    fetch_run.rate_limit_used = page.rate_limit.used
+                    session.flush()
+
+            except Exception as exc:
+                fetch_run.success = False
+                fetch_run.error_message = str(exc)
+                fetch_run.ended_at = utc_now()
+                logger.exception("Fetch run failed")
+                raise
+            else:
+                fetch_run.success = True
+                fetch_run.ended_at = utc_now()
+                logger.info("Fetch complete: processed %s users", total_processed)
+
+    def _get_or_create_repository(self, session: Session, repo_full_name: str) -> Repository:
+        stmt = select(Repository).where(Repository.full_name == repo_full_name)
+        repository = session.scalars(stmt).first()
+        if repository is None:
+            repository = Repository(full_name=repo_full_name)
+            session.add(repository)
+            session.flush()
+        return repository
+
+    def _load_resume_state(self, session: Session) -> tuple[Optional[str], int]:
+        if not self.args.resume:
+            return None, 0
+
+        stmt = (
+            select(FetchRun)
+            .where(FetchRun.repo_full_name == self.args.repo, FetchRun.api == "graphql")
+            .order_by(FetchRun.started_at.desc())
+        )
+        last_run = session.scalars(stmt).first()
+        if last_run and last_run.cursor_checkpoint:
+            logger.info("Resuming fetch from cursor %s (page %s)", last_run.cursor_checkpoint, last_run.page_checkpoint)
+            return last_run.cursor_checkpoint, last_run.page_checkpoint or 0
+        return None, 0
+
+    def _start_fetch_run(
+        self,
+        session: Session,
+        resume_cursor: Optional[str],
+        resume_page: int,
+    ) -> FetchRun:
+        fetch_run = FetchRun(
+            started_at=utc_now(),
+            repo_full_name=self.args.repo,
+            api="graphql",
+            page_size=self.args.page_size or self.config.default_page_size,
+            cursor_checkpoint=resume_cursor,
+            page_checkpoint=resume_page,
+            notes="resume" if resume_cursor else None,
+        )
+        session.add(fetch_run)
+        return fetch_run
+
+    def _process_page(
+        self,
+        session: Session,
+        repository: Repository,
+        fetch_run: FetchRun,
+        edges: list[StargazerEdge],
+    ) -> int:
+        processed = 0
+        for edge in edges:
+            snapshot = self._build_snapshot(edge)
+            if snapshot is None:
+                continue
+
+            user = self._upsert_user(session, snapshot)
+            self._upsert_stargazer(session, repository, user, edge)
+
+            if self.rest and self.args.rest_enrichment:
+                self._apply_rest_enrichment(session, user, snapshot)
+
+            if self.rest and self.args.events != "none" and snapshot.account_type == "User":
+                self._collect_events(session, fetch_run, user)
+
+            processed += 1
+
+        return processed
+
+    def _build_snapshot(self, edge: StargazerEdge) -> Optional[UserSnapshot]:
+        node = edge.node
+        github_id = node.get("github_id")
+        login = node.get("login")
+        account_type = node.get("type")
+
+        if github_id is None or login is None or account_type is None:
+            logger.debug("Skipping edge with missing identifiers: %s", node)
+            return None
+
+        return UserSnapshot(
+            github_id=int(github_id),
+            login=str(login),
+            account_type=str(account_type),
+            site_admin=node.get("site_admin"),
+            name=node.get("name"),
+            bio=node.get("bio"),
+            company=node.get("company"),
+            location=node.get("location"),
+            created_at=node.get("created_at"),
+            updated_at=node.get("updated_at"),
+            followers=node.get("followers"),
+            following=node.get("following"),
+            public_repos=node.get("public_repos"),
+            public_gists=node.get("public_gists"),
+            hireable=node.get("hireable"),
+            email_public=node.get("email_public"),
+            verified=node.get("verified"),
+            site=node.get("site"),
+        )
+
+    def _upsert_user(self, session: Session, snapshot: UserSnapshot) -> User:
+        stmt = select(User).where(User.github_id_int == snapshot.github_id)
+        user = session.scalars(stmt).first()
+
+        if user is None:
+            user = User(github_id_int=snapshot.github_id, login=snapshot.login, type=snapshot.account_type)
+            session.add(user)
+        else:
+            user.login = snapshot.login
+            user.type = snapshot.account_type
+
+        if snapshot.site_admin is not None:
+            user.site_admin = bool(snapshot.site_admin)
+        user.name = snapshot.name
+        user.bio = snapshot.bio
+        user.company = snapshot.company
+        user.location = snapshot.location
+        user.created_at = snapshot.created_at
+        user.updated_at = snapshot.updated_at
+        user.followers_count = snapshot.followers
+        user.following_count = snapshot.following
+        user.public_repos_count = snapshot.public_repos
+        user.public_gists_count = snapshot.public_gists
+        user.hireable = snapshot.hireable
+        user.email_public = snapshot.email_public
+        user.verified_badge = snapshot.verified
+        if snapshot.site:
+            user.site = snapshot.site
+
+        return user
+
+    def _upsert_stargazer(self, session: Session, repository: Repository, user: User, edge: StargazerEdge) -> None:
+        stmt = select(Stargazer).where(
+            Stargazer.repository_id == repository.id,
+            Stargazer.user_id == user.id,
+        )
+        stargazer = session.scalars(stmt).first()
+        now = utc_now()
+
+        if stargazer is None:
+            stargazer = Stargazer(
+                repository=repository,
+                user=user,
+                starred_at=edge.starred_at,
+                first_seen_at=edge.starred_at,
+                last_seen_at=now,
+                source="graphql",
+            )
+            session.add(stargazer)
+        else:
+            stargazer.starred_at = edge.starred_at
+            stargazer.last_seen_at = now
+
+    def _apply_rest_enrichment(self, session: Session, user: User, snapshot: UserSnapshot) -> None:
+        if self.rest is None:
+            return
+
+        profile = self.rest.fetch_user_profile(user.login)
+        user.site_admin = bool(profile.get("site_admin", False))
+        if profile.get("site"):
+            user.site = profile["site"]
+
+    def _collect_events(self, session: Session, fetch_run: FetchRun, user: User) -> None:
+        if self.rest is None:
+            return
+
+        max_pages = 1 if self.args.events == "recent" else 5
+        last_activity, count_90d = self.rest.fetch_recent_public_events(user.login, max_pages=max_pages)
+
+        metrics_version = "events-sampled"
+        stmt = select(UserMetric).where(
+            UserMetric.user_id == user.id,
+            UserMetric.metrics_version == metrics_version,
+        )
+        metric = session.scalars(stmt).first()
+        if metric is None:
+            metric = UserMetric(
+                user=user,
+                metrics_version=metrics_version,
+                updated_at=utc_now(),
+                source_run=fetch_run,
+            )
+            session.add(metric)
+
+        metric.last_public_activity_date = last_activity
+        metric.recent_event_count_90d = count_90d
+        metric.updated_at = utc_now()
+        metric.source_run = fetch_run
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch stargazers from GitHub into SQLite")
+    parser.add_argument("--repo", default="openclaw/openclaw", help="Repository in owner/name format")
+    parser.add_argument("--page-size", type=int, default=None, help="GraphQL page size (default 100)")
+    parser.add_argument("--max-users", type=int, default=None, help="Maximum number of users to fetch")
+    parser.add_argument("--resume", action="store_true", help="Resume from last stored cursor")
+    parser.add_argument(
+        "--events",
+        choices=["none", "recent", "full"],
+        default="none",
+        help="Optional public events sampling intensity",
+    )
+    parser.add_argument("--rest-enrichment", action="store_true", help="Enable REST enrichment for profiles")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    if args.page_size is not None and not (1 <= args.page_size <= 100):
+        parser.error("--page-size must be between 1 and 100")
+
+    if args.max_users is not None and args.max_users <= 0:
+        parser.error("--max-users must be a positive integer")
+
+    return args
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    setup_logging(verbose=args.verbose)
+    config = load_config()
+    runner = FetchRunner(config, args)
+    runner.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -256,6 +256,8 @@ class FetchRunner:
             return
 
         profile = self.rest.fetch_user_profile(user.login)
+        if profile is None:
+            return
         user.site_admin = bool(profile.get("site_admin", False))
         if profile.get("site"):
             user.site = profile["site"]
@@ -323,4 +325,3 @@ def main(argv: Optional[list[str]] = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-

--- a/src/github_graphql.py
+++ b/src/github_graphql.py
@@ -1,0 +1,373 @@
+"""GitHub GraphQL client focused on stargazer retrieval."""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Dict, Iterator, Optional
+
+import requests
+
+from .config import AppConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+STARGAZER_QUERY = """
+query ($owner: String!, $name: String!, $page_size: Int!, $cursor: String) {
+  rateLimit {
+    cost
+    limit
+    remaining
+    resetAt
+    used
+  }
+  repository(owner: $owner, name: $name) {
+    id
+    databaseId
+    stargazers(first: $page_size, after: $cursor, orderBy: {field: STARRED_AT, direction: DESC}) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        cursor
+        starredAt
+        node {
+          __typename
+          ... on User {
+            login
+            databaseId
+            name
+            bio
+            company
+            location
+            email
+            createdAt
+            updatedAt
+            followers {
+              totalCount
+            }
+            following {
+              totalCount
+            }
+            repositories(first: 0) {
+              totalCount
+            }
+            gists(first: 0) {
+              totalCount
+            }
+            isHireable
+            isSiteAdmin
+            isVerified
+            websiteUrl
+          }
+          ... on Organization {
+            login
+            databaseId
+            name
+            description
+            company
+            location
+            email
+            createdAt
+            updatedAt
+            isVerified
+            websiteUrl
+          }
+          ... on Bot {
+            login
+            databaseId
+            createdAt
+            updatedAt
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(frozen=True)
+class RateLimitInfo:
+    limit: Optional[int]
+    remaining: Optional[int]
+    reset_at: Optional[datetime]
+    used: Optional[int]
+    cost: Optional[int]
+
+
+@dataclass(frozen=True)
+class StargazerEdge:
+    cursor: str
+    starred_at: datetime
+    node: Dict[str, object]
+
+
+@dataclass(frozen=True)
+class StargazerPage:
+    edges: list[StargazerEdge]
+    has_next_page: bool
+    end_cursor: Optional[str]
+    rate_limit: RateLimitInfo
+
+
+class GithubGraphQLClient:
+    """Lightweight client for GitHub GraphQL requests."""
+
+    api_url = "https://api.github.com/graphql"
+
+    def __init__(self, config: AppConfig):
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {config.github_token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "openclaw-stargazer-analysis",
+            }
+        )
+        self.timeout = config.request_timeout
+        self.max_retries = config.max_retries
+        self.backoff_min = config.backoff_min_seconds
+        self.backoff_max = config.backoff_max_seconds
+
+    def iter_stargazers(
+        self,
+        repo_full_name: str,
+        page_size: int,
+        start_cursor: Optional[str] = None,
+        max_users: Optional[int] = None,
+    ) -> Iterator[StargazerPage]:
+        owner, name = repo_full_name.split("/", 1)
+        cursor = start_cursor
+        fetched = 0
+
+        while True:
+            page = self._fetch_page(owner, name, page_size, cursor)
+
+            edges = page.edges
+            if max_users is not None:
+                remaining = max_users - fetched
+                if remaining <= 0:
+                    break
+                if len(edges) > remaining:
+                    edges = edges[:remaining]
+                    page = replace(page, edges=edges)
+
+            yield page
+
+            count = len(edges)
+            fetched += count
+
+            if max_users is not None and fetched >= max_users:
+                break
+
+            if not page.has_next_page or not page.end_cursor:
+                break
+
+            cursor = page.end_cursor
+
+    def _fetch_page(self, owner: str, name: str, page_size: int, cursor: Optional[str]) -> StargazerPage:
+        payload = {
+            "query": STARGAZER_QUERY,
+            "variables": {
+                "owner": owner,
+                "name": name,
+                "page_size": page_size,
+                "cursor": cursor,
+            },
+        }
+
+        attempt = 0
+        while True:
+            attempt += 1
+            response = self.session.post(self.api_url, json=payload, timeout=self.timeout)
+            header_rate_limit = self._extract_rate_limit(response.headers)
+
+            if response.status_code == 401:
+                raise RuntimeError("GitHub GraphQL API returned 401 Unauthorized. Check token scope.")
+
+            if response.status_code == 403 and header_rate_limit.remaining == 0:
+                self._sleep_until_reset(header_rate_limit)
+                continue
+
+            if response.status_code >= 500:
+                if attempt >= self.max_retries:
+                    response.raise_for_status()
+                delay = self._compute_backoff(attempt)
+                logger.warning("Transient GraphQL error %s. Retrying in %.1fs", response.status_code, delay)
+                time.sleep(delay)
+                continue
+
+            response.raise_for_status()
+            payload_json = response.json()
+
+            if "errors" in payload_json:
+                errors = payload_json["errors"]
+                message = ", ".join(err.get("message", "Unknown error") for err in errors)
+                rate_limited = any(
+                    err.get("type") == "RATE_LIMITED" or "rate limit" in err.get("message", "").lower()
+                    for err in errors
+                )
+                if rate_limited and header_rate_limit.reset_at is not None:
+                    self._sleep_until_reset(header_rate_limit)
+                    continue
+                if attempt >= self.max_retries:
+                    raise RuntimeError(f"GraphQL query failed after retries: {message}")
+                delay = self._compute_backoff(attempt)
+                logger.warning("GraphQL returned errors: %s. Retrying in %.1fs", message, delay)
+                time.sleep(delay)
+                continue
+
+            data = payload_json["data"]
+            repo = data.get("repository")
+            if repo is None:
+                raise RuntimeError("Repository not found or access denied in GraphQL response.")
+
+            stargazers = repo["stargazers"]
+            page_info = stargazers["pageInfo"]
+            edges = [self._translate_edge(edge) for edge in stargazers["edges"]]
+
+            rate_limit_block = data.get("rateLimit") or {}
+            rate_limit = RateLimitInfo(
+                limit=rate_limit_block.get("limit"),
+                remaining=rate_limit_block.get("remaining"),
+                reset_at=self._parse_datetime(rate_limit_block.get("resetAt")),
+                used=rate_limit_block.get("used"),
+                cost=rate_limit_block.get("cost"),
+            )
+
+            return StargazerPage(
+                edges=edges,
+                has_next_page=page_info["hasNextPage"],
+                end_cursor=page_info.get("endCursor"),
+                rate_limit=rate_limit,
+            )
+
+    @staticmethod
+    def _translate_edge(edge: Dict[str, object]) -> StargazerEdge:
+        starred_at = GithubGraphQLClient._parse_datetime(edge["starredAt"])
+        cursor = edge["cursor"]
+        node_raw = edge["node"]
+        node = GithubGraphQLClient._translate_node(node_raw)
+        return StargazerEdge(cursor=cursor, starred_at=starred_at, node=node)
+
+    @staticmethod
+    def _translate_node(node: Dict[str, object]) -> Dict[str, object]:
+        typename = node["__typename"]
+        base = {
+            "type": typename,
+            "login": node.get("login"),
+            "github_id": node.get("databaseId"),
+            "created_at": GithubGraphQLClient._parse_datetime(node.get("createdAt")),
+            "updated_at": GithubGraphQLClient._parse_datetime(node.get("updatedAt")),
+        }
+
+        if typename == "User":
+            base.update(
+                {
+                    "name": node.get("name"),
+                    "bio": node.get("bio"),
+                    "company": node.get("company"),
+                    "location": node.get("location"),
+                    "followers": (node.get("followers") or {}).get("totalCount"),
+                    "following": (node.get("following") or {}).get("totalCount"),
+                    "public_repos": (node.get("repositories") or {}).get("totalCount"),
+                    "public_gists": (node.get("gists") or {}).get("totalCount"),
+                    "hireable": node.get("isHireable"),
+                    "email_public": bool(node.get("email")),
+                    "verified": node.get("isVerified"),
+                    "site_admin": node.get("isSiteAdmin"),
+                    "site": node.get("websiteUrl"),
+                }
+            )
+        elif typename == "Organization":
+            base.update(
+                {
+                    "name": node.get("name"),
+                    "bio": node.get("description"),
+                    "company": node.get("company"),
+                    "location": node.get("location"),
+                    "followers": None,
+                    "following": None,
+                    "public_repos": None,
+                    "public_gists": None,
+                    "hireable": None,
+                    "email_public": bool(node.get("email")),
+                    "verified": node.get("isVerified"),
+                    "site_admin": False,
+                    "site": node.get("websiteUrl"),
+                }
+            )
+        else:  # Bot or other actor
+            base.update(
+                {
+                    "name": None,
+                    "bio": None,
+                    "company": None,
+                    "location": None,
+                    "followers": None,
+                    "following": None,
+                    "public_repos": None,
+                    "public_gists": None,
+                    "hireable": None,
+                    "email_public": None,
+                    "verified": None,
+                    "site_admin": False,
+                    "site": None,
+                }
+            )
+
+        return base
+
+    @staticmethod
+    def _extract_rate_limit(headers: Dict[str, str]) -> RateLimitInfo:
+        limit = GithubGraphQLClient._safe_int(headers.get("X-RateLimit-Limit"))
+        remaining = GithubGraphQLClient._safe_int(headers.get("X-RateLimit-Remaining"))
+        used = GithubGraphQLClient._safe_int(headers.get("X-RateLimit-Used"))
+        reset_at = GithubGraphQLClient._parse_rate_limit_reset(headers.get("X-RateLimit-Reset"))
+        return RateLimitInfo(limit=limit, remaining=remaining, reset_at=reset_at, used=used, cost=None)
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+    @staticmethod
+    def _parse_rate_limit_reset(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            timestamp = int(value)
+        except ValueError:
+            return None
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+    def _sleep_until_reset(self, rate_limit: RateLimitInfo) -> None:
+        if rate_limit.reset_at is None:
+            raise RuntimeError("Rate limited but reset time unavailable.")
+        delta = (rate_limit.reset_at - datetime.now(timezone.utc)).total_seconds()
+        wait_time = max(delta, 1.0)
+        logger.warning("Hit GraphQL rate limit. Sleeping %.1fs until reset.", wait_time)
+        time.sleep(wait_time)
+
+    def _compute_backoff(self, attempt: int) -> float:
+        ceiling = min(self.backoff_max, self.backoff_min * (2 ** attempt))
+        return random.uniform(self.backoff_min, ceiling)
+
+    @staticmethod
+    def _safe_int(value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            return None

--- a/src/github_rest.py
+++ b/src/github_rest.py
@@ -43,9 +43,11 @@ class GithubRestClient:
         self.backoff_min = config.backoff_min_seconds
         self.backoff_max = config.backoff_max_seconds
 
-    def fetch_user_profile(self, login: str) -> Dict[str, object]:
+    def fetch_user_profile(self, login: str) -> Optional[Dict[str, object]]:
         path = f"/users/{login}"
-        response = self._request("GET", path)
+        response = self._request("GET", path, allow_not_found=True)
+        if response is None:
+            return None
         data = response.json()
         return {
             "site_admin": data.get("site_admin", False),
@@ -64,7 +66,14 @@ class GithubRestClient:
 
         for page in range(1, max_pages + 1):
             path = f"/users/{login}/events/public"
-            response = self._request("GET", path, params={"per_page": per_page, "page": page})
+            response = self._request(
+                "GET",
+                path,
+                params={"per_page": per_page, "page": page},
+                allow_not_found=True,
+            )
+            if response is None:
+                return last_activity, total_events
             events = response.json()
 
             if not isinstance(events, list):
@@ -85,7 +94,14 @@ class GithubRestClient:
 
         return last_activity, total_events
 
-    def _request(self, method: str, path: str, params: Optional[Dict[str, object]] = None) -> requests.Response:
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, object]] = None,
+        *,
+        allow_not_found: bool = False,
+    ) -> Optional[requests.Response]:
         attempt = 0
         url = f"{self.api_url}{path}"
         while True:
@@ -96,6 +112,10 @@ class GithubRestClient:
             if response.status_code == 403 and rate_limit.remaining == 0:
                 self._sleep_until_reset(rate_limit)
                 continue
+
+            if allow_not_found and response.status_code in {404, 410}:
+                logger.info("Optional REST resource %s returned %s. Skipping.", path, response.status_code)
+                return None
 
             if response.status_code >= 500:
                 if attempt >= self.max_retries:
@@ -149,4 +169,3 @@ class GithubRestClient:
         if not value:
             return None
         return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
-

--- a/src/github_rest.py
+++ b/src/github_rest.py
@@ -1,0 +1,152 @@
+"""GitHub REST API helpers for enrichment and events sampling."""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Optional, Tuple
+
+import requests
+
+from .config import AppConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RateLimitState:
+    limit: Optional[int]
+    remaining: Optional[int]
+    reset_at: Optional[datetime]
+
+
+class GithubRestClient:
+    """Thin wrapper around GitHub's REST APIs used for enrichment."""
+
+    api_url = "https://api.github.com"
+
+    def __init__(self, config: AppConfig):
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {config.github_token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "openclaw-stargazer-analysis",
+            }
+        )
+        self.timeout = config.request_timeout
+        self.max_retries = config.max_retries
+        self.backoff_min = config.backoff_min_seconds
+        self.backoff_max = config.backoff_max_seconds
+
+    def fetch_user_profile(self, login: str) -> Dict[str, object]:
+        path = f"/users/{login}"
+        response = self._request("GET", path)
+        data = response.json()
+        return {
+            "site_admin": data.get("site_admin", False),
+            "site": data.get("blog") or data.get("html_url"),
+            "type": data.get("type"),
+        }
+
+    def fetch_recent_public_events(
+        self,
+        login: str,
+        max_pages: int,
+        per_page: int = 100,
+    ) -> Tuple[Optional[datetime], int]:
+        total_events = 0
+        last_activity: Optional[datetime] = None
+
+        for page in range(1, max_pages + 1):
+            path = f"/users/{login}/events/public"
+            response = self._request("GET", path, params={"per_page": per_page, "page": page})
+            events = response.json()
+
+            if not isinstance(events, list):
+                break
+
+            for event in events:
+                created_at_raw = event.get("created_at")
+                created_at = self._parse_datetime(created_at_raw)
+                if created_at is None:
+                    continue
+                if last_activity is None or created_at > last_activity:
+                    last_activity = created_at
+                if created_at >= datetime.now(timezone.utc) - timedelta(days=90):
+                    total_events += 1
+
+            if len(events) < per_page:
+                break
+
+        return last_activity, total_events
+
+    def _request(self, method: str, path: str, params: Optional[Dict[str, object]] = None) -> requests.Response:
+        attempt = 0
+        url = f"{self.api_url}{path}"
+        while True:
+            attempt += 1
+            response = self.session.request(method, url, params=params, timeout=self.timeout)
+            rate_limit = self._parse_rate_limit(response.headers)
+
+            if response.status_code == 403 and rate_limit.remaining == 0:
+                self._sleep_until_reset(rate_limit)
+                continue
+
+            if response.status_code >= 500:
+                if attempt >= self.max_retries:
+                    response.raise_for_status()
+                delay = self._compute_backoff(attempt)
+                logger.warning("Transient REST error %s on %s. Retrying in %.1fs", response.status_code, path, delay)
+                time.sleep(delay)
+                continue
+
+            response.raise_for_status()
+            return response
+
+    def _parse_rate_limit(self, headers: Dict[str, str]) -> RateLimitState:
+        limit = self._safe_int(headers.get("X-RateLimit-Limit"))
+        remaining = self._safe_int(headers.get("X-RateLimit-Remaining"))
+        reset_at = self._parse_reset(headers.get("X-RateLimit-Reset"))
+        return RateLimitState(limit=limit, remaining=remaining, reset_at=reset_at)
+
+    def _sleep_until_reset(self, rate_limit: RateLimitState) -> None:
+        if rate_limit.reset_at is None:
+            raise RuntimeError("Rate limited but no reset time present in headers.")
+        delay = max((rate_limit.reset_at - datetime.now(timezone.utc)).total_seconds(), 1.0)
+        logger.warning("Hit REST rate limit. Sleeping %.1fs", delay)
+        time.sleep(delay)
+
+    def _compute_backoff(self, attempt: int) -> float:
+        ceiling = min(self.backoff_max, self.backoff_min * (2**attempt))
+        return random.uniform(self.backoff_min, ceiling)
+
+    @staticmethod
+    def _safe_int(value: Optional[str]) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_reset(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            epoch = int(value)
+        except ValueError:
+            return None
+        return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+    @staticmethod
+    def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -206,8 +206,10 @@ class MetricsRunner:
         return not any([user.name, user.bio, user.company])
 
     def _low_social_presence(self, user: User) -> bool:
-        followers = user.followers_count or 0
-        following = user.following_count or 0
+        followers = user.followers_count
+        following = user.following_count
+        if followers is None or following is None:
+            return False
         return followers <= 1 and following <= 1
 
     def _no_public_assets(self, user: User) -> bool:

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,245 @@
+"""Compute user metrics and bot likelihood scores."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from .config import AppConfig, load_config
+from .db import FetchRun, Repository, User, UserMetric, init_db, session_scope
+from .utils import setup_logging, utc_now
+
+
+logger = logging.getLogger(__name__)
+
+BOT_LOGIN_PATTERN = re.compile(r"(bot|ci|auto|build|action)s?$", re.IGNORECASE)
+BOT_COMPANY_PATTERN = re.compile(r"(bot|automation|ai|script)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class MetricInput:
+    user: User
+    events_metric: Optional[UserMetric]
+
+
+@dataclass(frozen=True)
+class MetricResult:
+    follower_following_ratio: Optional[float]
+    bot_score: int
+    bot_label: str
+    last_public_activity_date: Optional[datetime]
+    recent_event_count_90d: Optional[int]
+
+
+class MetricsRunner:
+    """Encapsulates logic for computing bot scores."""
+
+    def __init__(self, config: AppConfig, args: argparse.Namespace):
+        self.config = config
+        self.args = args
+        engine = init_db(config.database_url)
+        self.session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    def run(self) -> None:
+        with session_scope(self.session_factory) as session:
+            repository = self._get_repository(session)
+            if repository is None:
+                raise ValueError(f"Repository {self.args.repo} was not found. Run fetch first.")
+
+            source_run = self._get_latest_fetch_run(session)
+            events_metrics = self._load_events_metrics(session)
+
+            stmt = (
+                select(User)
+                .join(User.stargazer_entries)
+                .join(User.stargazer_entries.property.mapper.class_.repository)
+                .where(Repository.full_name == self.args.repo)
+                .distinct()
+            )
+            users = session.scalars(stmt).all()
+
+            logger.info("Computing metrics for %s users", len(users))
+            for user in users:
+                events_metric = events_metrics.get(user.id)
+                result = self._compute_metrics(MetricInput(user=user, events_metric=events_metric))
+                self._persist_metric(session, user, result, source_run)
+
+    def _get_repository(self, session: Session) -> Optional[Repository]:
+        stmt = select(Repository).where(Repository.full_name == self.args.repo)
+        return session.scalars(stmt).first()
+
+    def _get_latest_fetch_run(self, session: Session) -> Optional[FetchRun]:
+        stmt = (
+            select(FetchRun)
+            .where(FetchRun.repo_full_name == self.args.repo, FetchRun.success.is_(True))
+            .order_by(FetchRun.started_at.desc())
+        )
+        return session.scalars(stmt).first()
+
+    def _load_events_metrics(self, session: Session) -> Dict[int, UserMetric]:
+        stmt = select(UserMetric).where(UserMetric.metrics_version == "events-sampled")
+        return {metric.user_id: metric for metric in session.scalars(stmt)}
+
+    def _compute_metrics(self, metric_input: MetricInput) -> MetricResult:
+        user = metric_input.user
+
+        ratio = self._compute_ratio(user)
+        last_public_activity = (
+            metric_input.events_metric.last_public_activity_date
+            if metric_input.events_metric and metric_input.events_metric.last_public_activity_date
+            else None
+        )
+        recent_event_count = (
+            metric_input.events_metric.recent_event_count_90d if metric_input.events_metric else None
+        )
+
+        score = 0
+
+        if user.type == "Bot":
+            score += 80
+
+        if BOT_LOGIN_PATTERN.search(user.login):
+            score += 15
+
+        account_age_days = self._account_age_days(user)
+        if account_age_days is not None:
+            if account_age_days < 7:
+                score += 25
+            elif account_age_days < 30:
+                score += 15
+            elif account_age_days < 90:
+                score += 5
+
+        if self._profile_blank(user):
+            score += 10
+
+        if self._low_social_presence(user):
+            score += 10
+
+        if ratio is not None and (ratio >= 10 or ratio <= 0.1):
+            score += 10
+
+        if recent_event_count is not None and recent_event_count == 0:
+            score += 10
+        elif last_public_activity is None:
+            # missing data contributes zero
+            pass
+
+        if self._no_public_assets(user):
+            score += 10
+
+        if user.company and BOT_COMPANY_PATTERN.search(user.company):
+            score += 10
+
+        if user.site_admin:
+            score -= 30
+
+        score = max(0, min(100, score))
+        label = self._score_to_label(score)
+
+        return MetricResult(
+            follower_following_ratio=ratio,
+            bot_score=score,
+            bot_label=label,
+            last_public_activity_date=last_public_activity,
+            recent_event_count_90d=recent_event_count,
+        )
+
+    def _persist_metric(
+        self,
+        session: Session,
+        user: User,
+        result: MetricResult,
+        source_run: Optional[FetchRun],
+    ) -> None:
+        stmt = select(UserMetric).where(
+            UserMetric.user_id == user.id,
+            UserMetric.metrics_version == self.args.metrics_version,
+        )
+        metric = session.scalars(stmt).first()
+        if metric is None:
+            metric = UserMetric(
+                user=user,
+                metrics_version=self.args.metrics_version,
+                updated_at=utc_now(),
+                source_run=source_run,
+            )
+            session.add(metric)
+
+        metric.follower_following_ratio = result.follower_following_ratio
+        metric.bot_score = result.bot_score
+        metric.bot_label = result.bot_label
+        metric.updated_at = utc_now()
+        metric.source_run = source_run
+
+        if result.last_public_activity_date:
+            metric.last_public_activity_date = result.last_public_activity_date
+        if result.recent_event_count_90d is not None:
+            metric.recent_event_count_90d = result.recent_event_count_90d
+
+    def _compute_ratio(self, user: User) -> Optional[float]:
+        followers = user.followers_count
+        following = user.following_count
+        if followers is None or following is None:
+            return None
+        if following == 0:
+            return float("inf") if followers > 0 else None
+        return round(followers / following, 2)
+
+    def _account_age_days(self, user: User) -> Optional[int]:
+        if user.created_at is None:
+            return None
+        created_at = user.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        delta = utc_now() - created_at
+        return max(delta.days, 0)
+
+    def _profile_blank(self, user: User) -> bool:
+        return not any([user.name, user.bio, user.company])
+
+    def _low_social_presence(self, user: User) -> bool:
+        followers = user.followers_count or 0
+        following = user.following_count or 0
+        return followers <= 1 and following <= 1
+
+    def _no_public_assets(self, user: User) -> bool:
+        repos = user.public_repos_count
+        gists = user.public_gists_count
+        if repos is None or gists is None:
+            return False
+        return repos == 0 and gists == 0
+
+    def _score_to_label(self, score: int) -> str:
+        if score >= 60:
+            return "likely_bot"
+        if score >= 40:
+            return "suspicious"
+        return "likely_human"
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute bot metrics for stargazers")
+    parser.add_argument("--repo", default="openclaw/openclaw", help="Repository in owner/name format")
+    parser.add_argument("--metrics-version", default="bot-v1", help="Metrics version label")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    setup_logging(verbose=args.verbose)
+    config = load_config()
+    runner = MetricsRunner(config, args)
+    runner.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/report.py
+++ b/src/report.py
@@ -1,0 +1,234 @@
+"""Generate figures and a Markdown report summarizing the analysis."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from sqlalchemy.orm import sessionmaker
+
+from .analyze import load_analysis_dataframe
+from .config import AppConfig, load_config
+from .db import init_db, session_scope
+from .utils import setup_logging, utc_now
+
+
+logger = logging.getLogger(__name__)
+
+
+class Reporter:
+    """Produces visualisations and a Markdown report."""
+
+    def __init__(self, config: AppConfig, args: argparse.Namespace):
+        self.config = config
+        self.repo = args.repo
+        self.metrics_version = args.metrics_version
+        self.data_dir = Path(args.data_dir)
+        self.fig_dir = Path(args.fig_dir)
+        self.out_file = Path(args.out_file)
+        engine = init_db(config.database_url)
+        self.session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False, future=True)
+
+    def run(self) -> None:
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+        self.fig_dir.mkdir(parents=True, exist_ok=True)
+        self.out_file.parent.mkdir(parents=True, exist_ok=True)
+
+        with session_scope(self.session_factory) as session:
+            df = load_analysis_dataframe(session, self.repo, self.metrics_version)
+
+        if df.empty:
+            logger.warning("No data found for report. Run fetch, metrics, and analyze first.")
+            return
+
+        sns.set_theme(style="whitegrid")
+
+        figures = {}
+        figures["bot_label_distribution"] = self._plot_bot_labels(df)
+        figures["bot_score_histogram"] = self._plot_bot_scores(df)
+        figures["account_age_histogram"] = self._plot_account_age(df)
+        figures["top_locations"] = self._plot_locations(df)
+        figures["stars_time_series"] = self._plot_time_series(df)
+
+        report_content = self._build_report(df, figures)
+        self.out_file.write_text(report_content)
+        logger.info("Report written to %s", self.out_file)
+
+    def _save_figure(self, fig: plt.Figure, name: str) -> str:
+        path = self.fig_dir / f"{name}.png"
+        fig.tight_layout()
+        fig.savefig(path, dpi=200)
+        plt.close(fig)
+        return path.name
+
+    def _plot_bot_labels(self, df: pd.DataFrame) -> str:
+        counts = df["bot_label"].dropna().value_counts().reset_index()
+        counts.columns = ["bot_label", "count"]
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.bar(counts["bot_label"], counts["count"], color="#2b8cbe")
+        ax.set_title("Bot classification distribution")
+        ax.set_xlabel("Bot label")
+        ax.set_ylabel("Users")
+        return self._save_figure(fig, "bot_label_distribution")
+
+    def _plot_bot_scores(self, df: pd.DataFrame) -> str:
+        fig, ax = plt.subplots(figsize=(6, 4))
+        sns.histplot(df["bot_score"].dropna(), bins=10, color="#5b8def", ax=ax)
+        ax.set_title("Bot score histogram")
+        ax.set_xlabel("Bot score")
+        ax.set_ylabel("Users")
+        return self._save_figure(fig, "bot_score_histogram")
+
+    def _plot_account_age(self, df: pd.DataFrame) -> str:
+        ages = df["account_age_days"].dropna()
+        if ages.empty:
+            fig, ax = plt.subplots(figsize=(6, 4))
+            ax.text(0.5, 0.5, "No account age data", ha="center", va="center")
+            ax.axis("off")
+            return self._save_figure(fig, "account_age_histogram")
+
+        fig, ax = plt.subplots(figsize=(6, 4))
+        sns.histplot(ages, bins=20, color="#f77f00", ax=ax)
+        ax.set_title("Account age distribution")
+        ax.set_xlabel("Account age (days)")
+        ax.set_ylabel("Users")
+        return self._save_figure(fig, "account_age_histogram")
+
+    def _plot_locations(self, df: pd.DataFrame) -> str:
+        locations = (
+            df["location"].dropna().astype(str).str.strip().replace({"": None}).dropna().str.title().value_counts().head(10)
+        )
+        if locations.empty:
+            fig, ax = plt.subplots(figsize=(6, 4))
+            ax.text(0.5, 0.5, "No location data", ha="center", va="center")
+            ax.axis("off")
+            return self._save_figure(fig, "top_locations")
+
+        fig, ax = plt.subplots(figsize=(7, 5))
+        ax.barh(range(len(locations)), locations.values, color="#1b9e77")
+        ax.set_yticks(range(len(locations)))
+        ax.set_yticklabels(locations.index)
+        ax.set_title("Top locations")
+        ax.set_xlabel("Users")
+        ax.set_ylabel("Location")
+        return self._save_figure(fig, "top_locations")
+
+    def _plot_time_series(self, df: pd.DataFrame) -> str:
+        stars = df[["starred_at"]].dropna().copy()
+        if stars.empty:
+            fig, ax = plt.subplots(figsize=(6, 4))
+            ax.text(0.5, 0.5, "No star timeline data", ha="center", va="center")
+            ax.axis("off")
+            return self._save_figure(fig, "stars_time_series")
+
+        starred_series = stars["starred_at"]
+        if starred_series.dt.tz is not None:
+            starred_series = starred_series.dt.tz_localize(None)
+        stars["month"] = starred_series.dt.to_period("M").dt.to_timestamp()
+        timeline = stars.groupby("month").size().reset_index(name="stars")
+
+        fig, ax = plt.subplots(figsize=(7, 4))
+        sns.lineplot(data=timeline, x="month", y="stars", marker="o", ax=ax)
+        ax.set_title("Stars over time")
+        ax.set_xlabel("Month")
+        ax.set_ylabel("Stars")
+        ax.tick_params(axis="x", rotation=45)
+        return self._save_figure(fig, "stars_time_series")
+
+    def _build_report(self, df: pd.DataFrame, figures: dict[str, str]) -> str:
+        total = len(df)
+        likely_bot = df.loc[df["bot_score"] >= 60]
+        suspicious = df.loc[(df["bot_score"] >= 40) & (df["bot_score"] < 60)]
+        likely_human = df.loc[df["bot_score"] < 40]
+
+        bot_pct = (len(likely_bot) / total * 100) if total else 0
+        suspicious_pct = (len(suspicious) / total * 100) if total else 0
+        human_pct = (len(likely_human) / total * 100) if total else 0
+
+        top_locations = (
+            df["location"].dropna().astype(str).str.strip().replace({"": None}).dropna().str.title().value_counts().head(5)
+        )
+        location_summary = ", ".join(f"{loc} ({count})" for loc, count in top_locations.items()) or "None reported"
+
+        avg_account_age = df["account_age_days"].dropna().mean()
+        avg_followers = df["followers_count"].dropna().mean()
+        events_sampled = df["recent_event_count_90d"].dropna()
+        events_coverage = len(events_sampled) / total * 100 if total else 0
+
+        generated_at = utc_now().strftime("%Y-%m-%d %H:%M UTC")
+
+        return "\n".join(
+            [
+                f"# Stargazer Bot Analysis for {self.repo}",
+                "",
+                "## Executive Summary",
+                f"- Total stargazers analyzed: **{total}**",
+                f"- Likely bots (score ≥60): **{len(likely_bot)} ({bot_pct:.1f}%)**",
+                f"- Suspicious (score 40–59): **{len(suspicious)} ({suspicious_pct:.1f}%)**",
+                f"- Likely human (score ≤39): **{len(likely_human)} ({human_pct:.1f}%)**",
+                f"- Top locations: {location_summary}",
+                "",
+                "## Methodology",
+                "- Fetched stargazers via GitHub GraphQL with deterministic pagination and rate-limit handling.",
+                f"- Stored normalized records in SQLite and computed metrics via `metrics.py` version `{self.metrics_version}`.",
+                "- Optional REST enrichment provided site admin status, websites, and public events sampling.",
+                "",
+                "## Bot Model",
+                "- Heuristic scoring spanning account type, naming patterns, profile completeness, social graph,",
+                "  activity, and repository/gist presence.",
+                "- Key thresholds: +80 for GitHub Bot accounts, +25 for accounts younger than 7 days,",
+                "  +10 for blank profiles, −30 for site-admin verified staff.",
+                "",
+                "## Results",
+                f"- Average account age: **{avg_account_age:.0f} days** (where available).",
+                f"- Average followers: **{avg_followers:.1f}** (where available).",
+                f"- Public event sampling coverage: **{events_coverage:.1f}%** of users.",
+                f"- ![Bot labels](figures/{figures['bot_label_distribution']})",
+                f"- ![Bot scores](figures/{figures['bot_score_histogram']})",
+                f"- ![Account age](figures/{figures['account_age_histogram']})",
+                f"- ![Top locations](figures/{figures['top_locations']})",
+                f"- ![Stars over time](figures/{figures['stars_time_series']})",
+                "",
+                "## Validation",
+                "- Manual spot checks recommended for high-scoring accounts.",
+                "- Event sampling inspects recent public activity but omits private/org events.",
+                "",
+                "## Limitations",
+                "- GitHub profiles may omit key signals (location, company).",
+                "- Heuristic classifier is deterministic and can mislabel niche communities.",
+                "- Event sampling capped to recent public events; dormant users may be legitimate.",
+                "",
+                "## Appendix",
+                f"- Data exports available in `{self.data_dir}`.",
+                f"- Figures saved in `{self.fig_dir}`.",
+                f"- Report generated at {generated_at}.",
+            ]
+        )
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create visual report from stargazer metrics")
+    parser.add_argument("--repo", default="openclaw/openclaw", help="Repository in owner/name format")
+    parser.add_argument("--metrics-version", default="bot-v1", help="Metrics version to report on")
+    parser.add_argument("--data-dir", default="reports/data", help="Directory containing analysis CSVs")
+    parser.add_argument("--fig-dir", default="reports/figures", help="Directory for output figures")
+    parser.add_argument("--out-file", default="reports/report.md", help="Path to Markdown report")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    setup_logging(verbose=args.verbose)
+    config = load_config()
+    reporter = Reporter(config, args)
+    reporter.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,37 @@
+"""Shared utilities used across the pipeline."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Iterator
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware ``datetime`` representing the current UTC time."""
+
+    return datetime.now(timezone.utc)
+
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure basic logging for CLI scripts."""
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+@contextmanager
+def log_exceptions(logger: logging.Logger, context: str) -> Iterator[None]:
+    """Context manager to log unexpected exceptions before re-raising."""
+
+    try:
+        yield
+    except Exception:  # pragma: no cover - strict re-raise after logging
+        logger.exception("Unhandled exception while %s", context)
+        raise
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from src.metrics import MetricsRunner
+from src.utils import utc_now
+
+
+def test_utc_now_returns_timezone_aware_datetime() -> None:
+    value = utc_now()
+    assert value.tzinfo is not None
+
+
+def test_score_to_label_thresholds() -> None:
+    runner = MetricsRunner.__new__(MetricsRunner)  # bypass __init__
+    assert runner._score_to_label(75) == "likely_bot"
+    assert runner._score_to_label(45) == "suspicious"
+    assert runner._score_to_label(10) == "likely_human"


### PR DESCRIPTION
Implements the end-to-end stargazer analysis pipeline for openclaw/openclaw per Issue #1.

- GraphQL-first data fetch with pagination, rate-limit/backoff, and SQLite persistence (normalized schema)
- Optional REST-based enrichment and events sampling (budgeted)
- Deterministic bot-likelihood scoring model (0–100) and metrics
- Aggregate analysis, figures, and report generation
- Usage docs and troubleshooting notes

Closes #1.

Test summary (local):
- Seeded demo data: `python scripts/seed_sample_data.py`
- Metrics: `python -m src.metrics --repo openclaw/openclaw --metrics-version bot-v1`
- Analysis: `python -m src.analyze --repo openclaw/openclaw --metrics-version bot-v1 --out-dir reports/data`
- Report: `python -m src.report --repo openclaw/openclaw --metrics-version bot-v1 --data-dir reports/data --fig-dir reports/figures --out-file reports/report.md`
- `pytest` → 2 passed / 0 failed / 0 skipped
- `ruff check src scripts tests` → no issues